### PR TITLE
Proposal to support FA omega notation for parsing

### DIFF
--- a/FattyAcids.g4
+++ b/FattyAcids.g4
@@ -116,12 +116,16 @@ functional_group : multi_functional_group | single_functional_group | epoxy | me
 pos_neg : '(+/-)-' | '(+)-' | '(-)-';
 
 double_bond_positions : double_bond_positions_pure DASH | ROB double_bond_positions_pure RCB DASH | double_bond_positions_pure | ROB double_bond_positions_pure RCB;
-double_bond_positions_pure : double_bond_positions_pure pos_separator double_bond_positions_pure | double_bond_position;
+double_bond_positions_pure : double_bond_positions_pure pos_separator double_bond_positions_pure | double_bond_position | double_bond_position_omega;
 double_bond_position : db_number | db_number cistrans_b | db_number PRIME | db_number PRIME cistrans_b | cistrans_b;
+double_bond_position_omega: db_number DASH omega_position | db_number SPACE omega_position;
 cistrans_b : cistrans | ROB cistrans RCB;
 cistrans : 'e' | 'z' | 'r' | 's' | 'a' | 'b' | 'c';
 db_number : number;
 fg_pos_summary : functional_positions DASH;
+omega_position : omega omega_pos | omega DASH omega_pos | omega SPACE omega_pos;
+omega : 'omega' | 'ω' | '';
+omega_pos : number;
 
 multi_functional_group : functional_positions DASH functional_length functional_group_type | functional_positions DASH functional_group_type;
 functional_length : notation_last_digit | notation_second_digit | notation_last_digit notation_second_digit;


### PR DESCRIPTION
The omega notation for FA double bond positions counting from the methyl end of the FA is predominantly used in biology and microbial FA composition reporting. 

Example of nomenclature: 

- https://www.ebi.ac.uk/chebi/chebiOntology.do?chebiId=CHEBI:140957
- https://biotechnologyforbiofuels.biomedcentral.com/articles/10.1186/s13068-015-0251-x/tables/1
- https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7511782/

Many of these nomenclature examples result from FA FAME GC-MS analysis performed by DSMZ. Unfortunately, these names are not easily found in either LIPID MAPS, nor SwissLipids, even though their naming is not too far off what we already support.

According to the LipidWeb reference, the older omega nomenclature should be replaced with the n nomenclature:
https://www.lipidmaps.org/resources/lipid_web?page=lipids/fa-eic.html

We should try to provide normalization of both variants to the latest shorthand nomenclature.